### PR TITLE
A few fixes and updates...

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,29 +31,34 @@ With the `--icounter` and `--butthurt` the output `dolphin.state` can be modifie
 [+] Read 40 bytes from dolphin.state
 [+] Updating icounter to 1337
 [+] Saving dolphin state to new-dolphin.state
-[+] Calculated new checksum: 186
+[+] Calculated new checksum: 161
 [+] Saved output to: new-dolphin.state
 [+] SavedStructHeader
     magic:                       208
     version:                     1
-    checksum:                    186
+    checksum:                    161
     flags:                       0
     timestamp:                   0
 
 [+] DolphinStoreData
-    DolphinAppSubGhz:            0
-    DolphinAppRfid:              0
-    DolphinAppNfc:               6
-    DolphinAppIr:                0
-    DolphinAppIbutton:           0
-    DolphinAppBadusb:            0
-    DolphinAppU2f:               0
-    butthurt_daily_limit:        6
+    DolphinAppSubGhz:		 0
+    DolphinAppRfid:		 20
+    DolphinAppNfc:		 20
+    DolphinAppIr:		 0
+    DolphinAppIbutton:		 0
+    DolphinAppBadusb:		 0
+    DolphinAppU2f:		 2
+    butthurt_daily_limit:	 46
 
-    flags:                       0
-    icounter:                    1337
-    butthurt:                    0
-    timestamp:                   1647147878 (2022-03-13 06:04:38)
+    flags:			 0
+    icounter:			 1337
+    butthurt:			 14
+    timestamp:			 1678561214 (2023-03-11 14:00:14)
+
+[+] Passport
+    level:			 2
+    mood:			 Angry enough to leave
+    percent complete:		 69.13%
 ``` 
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Reads the `DolphinStoreData` struct from `dolphin.state` files.
 
 ### Reading 
 
-`python3 dolphin_state.py <path-to-dolphine.state>`
+`python3 dolphin_state.py <path-to-dolphin.state>`
 
 ### Writing 
 
@@ -14,7 +14,7 @@ Reads the `DolphinStoreData` struct from `dolphin.state` files.
 
 **butthurt**: Level of happiness flipper has - `BUTTHURT_MAX = 14`
 
-With the `--icounter` and `--butthurt` the output `dolphine.state` can be modified. The script will automaticly update the checksum for the file. The `--out` parameter must be set. 
+With the `--icounter` and `--butthurt` the output `dolphin.state` can be modified. The script will automaticly update the checksum for the file. The `--out` parameter must be set. 
 
 #### Setting EXP
 `python3 dolphin_state.py dolphin.state --icounter=1337 --out dolphin-new.state`

--- a/dolphin-state.py
+++ b/dolphin-state.py
@@ -88,10 +88,10 @@ with open(args.file, 'rb') as reader:
 
 print("[+] Read", len(buffer), "bytes from", args.file)
 
-if args.icounter:
+if args.icounter is not None:
     buffer = update_icounter(buffer, args.icounter)
 
-if args.butthurt:
+if args.butthurt is not None:
     buffer = update_butthurt(buffer, args.butthurt)
 
 if args.out: 

--- a/dolphin-state.py
+++ b/dolphin-state.py
@@ -14,6 +14,14 @@ HEADER_SIZE = 8
 DolphinAppMAX = 7
 BUTTHURT_MAX = 14
 
+# https://github.com/flipperdevices/flipperzero-firmware/blob/3c77ae2eb88db05e4bc8a51c7a0dbd64943c0f9f/applications/dolphin/helpers/dolphin_state.c
+LEVEL2_THRESHOLD = 300
+LEVEL3_THRESHOLD = 1800
+
+# https://github.com/flipperdevices/flipperzero-firmware/blob/3c77ae2eb88db05e4bc8a51c7a0dbd64943c0f9f/applications/dolphin/passport/passport.c
+moods = [{"name": "Happy", "max_butthurt": 4}, {"name": "Ok", "max_butthurt": 9}, {"name": "Angry", "max_butthurt": BUTTHURT_MAX}]
+
+
 # https://github.com/flipperdevices/flipperzero-firmware/blob/3c77ae2eb88db05e4bc8a51c7a0dbd64943c0f9f/lib/toolbox/saved_struct.c
 def unpack_header(buffer):
     (magic, version, checksum, flags, timestamp) = struct.unpack('BBBBI', buffer[0:HEADER_SIZE])
@@ -41,10 +49,37 @@ def unpack_state(buffer):
     print()
     
     (flags, icounter, butthurt, timestamp) = struct.unpack("IIIQ", buffer[HEADER_SIZE+8:])
+
     print("    flags:\t\t\t", flags)
     print("    icounter:\t\t\t", icounter)
     print("    butthurt:\t\t\t", butthurt)
     print("    timestamp:\t\t\t", timestamp, '(' + str(datetime.fromtimestamp(timestamp)) + ')')
+    print()
+
+    if icounter >= LEVEL3_THRESHOLD:
+      # There's only 3 levels, so percentage is at 100% once we hit level 3
+      passport_pct = 100
+      passport_level = 3
+    elif icounter >= LEVEL2_THRESHOLD:
+      passport_pct = ((icounter - LEVEL2_THRESHOLD) / (LEVEL3_THRESHOLD - LEVEL2_THRESHOLD)) * 100
+      passport_level = 2
+    else:
+      passport_pct = (icounter / LEVEL2_THRESHOLD) * 100
+      passport_level = 1
+
+    for mood in reversed(moods):
+      if (butthurt <= mood["max_butthurt"]): passport_mood = mood["name"]
+
+    # https://github.com/flipperdevices/flipperzero-firmware/tree/c97d9a633ebf94af2365c6e17760b44cd8c88c60/assets/dolphin/external/L1_Leaving_sad_128x64
+    # and
+    # https://github.com/flipperdevices/flipperzero-firmware/blob/c97d9a633ebf94af2365c6e17760b44cd8c88c60/assets/dolphin/external/manifest.txt
+    # If butthurt == BUTTHURT_MAX, there's a chance the L1_Leaving_sad animation will play
+    if (butthurt == BUTTHURT_MAX): passport_mood += " enough to leave"
+
+    print("[+] Passport")
+    print("    level:\t\t\t", passport_level)
+    print("    mood:\t\t\t", passport_mood)
+    print("    percent complete:\t\t %.2f%%" % passport_pct)
 
 def update_icounter(buffer, value): 
     print("[+] Updating icounter to", value)

--- a/dolphin-state.py
+++ b/dolphin-state.py
@@ -52,7 +52,7 @@ def update_icounter(buffer, value):
 
 def update_butthurt(buffer, value):
     if value > BUTTHURT_MAX:
-        print('[-]', value, 'is way to much butthurt for Flipper to handle (Max=14). Try decreasing it.') 
+        print('[-]', value, 'is way too much butthurt for Flipper to handle (Max=14). Try decreasing it.') 
         print('[-] Skipping update_butthurt')
         return buffer 
         


### PR DESCRIPTION
Hey, nice util!  After neglecting my poor flipper for a bit too long, I figured as long as it's a hacking multi-tool, I might as well figure out how to hack the poor dolphin's brain as well... while starting to dig through the firmware source to figure out the format of .dolphin.state, it occurred to me to check to see if anyone else has done this yet.

Sure enough, I found this tool.  Thank you for that!

There's a couple of small spelling fixes I've committed to my fork (those bother me far more than they should, bleh!), and a bugfix for both --butthurt and --icounter which caused them to not accept perfectly valid argument '0'.  Argh, python.  :)

While I was at it, I dug through the passport code in the firmware to figure out how it used the data in .dolphin.state to determine mood, level and percent complete values, and added passport display to dolphin-state.py - this gives the numbers for icounter and butthurt some much-needed context.  See updated README.md for new example output!

Anyway, thank you again for doing the legwork on parsing .dolphin.state - that saved me far more hours than I would like to have to admit to.  ;)